### PR TITLE
Fixed error with downloading Opus datasets

### DIFF
--- a/transtokenizers/transtokenizers.py
+++ b/transtokenizers/transtokenizers.py
@@ -145,10 +145,16 @@ def get_dataset_iterator(dataset_name: str, source_language: str, target_languag
         src_script = src_lang.script if src_lang.script else DEFAUT_SCRIPT_BY_LANG[src_lang.to_alpha3()]
         tgt_script = tgt_lang.script if tgt_lang.script else DEFAUT_SCRIPT_BY_LANG[tgt_lang.to_alpha3()]
 
+        languages = [
+            src_lang.to_alpha3() + '_' + src_script,
+            tgt_lang.to_alpha3() + '_' + tgt_script
+        ]
+        languages.sort()
+
         # load the dataset
         dataset = load_dataset(
             dataset_name,
-            f"{src_lang.to_alpha3()}_{src_script}-{tgt_lang.to_alpha3()}_{tgt_script}",
+            languages[0] + '-' + languages[1],
             split='train',
             streaming=True,
             trust_remote_code=True

--- a/transtokenizers/transtokenizers.py
+++ b/transtokenizers/transtokenizers.py
@@ -125,7 +125,9 @@ def get_dataset_iterator(dataset_name: str, source_language: str, target_languag
         target_language = Language.get(target_language).language if len(target_language) != 2 else target_language
 
         # load the dataset
-        dataset = load_dataset(dataset_name, lang1=source_language, lang2=target_language, streaming=True, trust_remote_code=True)
+        languages = [source_language, target_language]
+        languages.sort()
+        dataset = load_dataset(dataset_name, lang1=languages[0], lang2=languages[1], streaming=True, trust_remote_code=True)
 
         # wrap the dataset iterator so it returns a tuple of the source and target sentences
         class DatasetWrapper(Iterator):


### PR DESCRIPTION

To download the Opus OpenSubtitles dataset, you need to specify the languages in alphabetic order and not as source/target language.

Added a quick sort for the source and target language to fix this issue.